### PR TITLE
Links the variants to epoch data

### DIFF
--- a/deeprank/learn/NeuralNet.py
+++ b/deeprank/learn/NeuralNet.py
@@ -838,10 +838,15 @@ class NeuralNet():
                 variant_row = [os.path.basename(variant.pdb_path), variant.chain_id, variant.residue_id,
                                variant.wild_type_amino_acid.name, variant.variant_amino_acid.name]
 
-                if variant.protein_accession is not None and variant.protein_residue_number is not None:
-                    variant_row += [variant.protein_accession, str(variant.protein_residue_number)]
+                if variant.protein_accession is not None:
+                    variant_row.append(variant.protein_accession)
                 else:
-                    variant_row += ["", ""]
+                    variant_row.append("")
+
+                if variant.protein_residue_number is not None:
+                    variant_row.append(str(variant.protein_residue_number))
+                else:
+                    variant_row.append("")
 
                 data['variant'].append(variant_row)
 

--- a/deeprank/models/variant.py
+++ b/deeprank/models/variant.py
@@ -18,11 +18,14 @@ class PdbVariantSelection:
         pssm_paths_by_chain (dict(str, str), optional): the paths of the pssm files per chain id, associated with the pdb file
         variant_class (VariantClass, optional): if known, the expected classification of the variant
         insertion_code (str): insertion code of the residue, default is None
+        protein_accession (str): accession code, to identify the protein that this variant was reported in
+        protein_residue_number (int): number of the residue in the protein that this variant was reported in
     """
 
     def __init__(self, pdb_path, chain_id, residue_number,
                  wild_type_amino_acid, variant_amino_acid,
-                 pssm_paths_by_chain=None, variant_class=None, insertion_code=None):
+                 pssm_paths_by_chain=None, variant_class=None, insertion_code=None,
+                 protein_accession=None, protein_residue_number=None):
         self._pdb_path = pdb_path
         self._chain_id = chain_id
         self._residue_number = residue_number
@@ -31,6 +34,8 @@ class PdbVariantSelection:
         self._variant_amino_acid = variant_amino_acid
         self._pssm_paths_by_chain = pssm_paths_by_chain
         self._variant_class = variant_class
+        self._protein_accession = protein_accession
+        self._protein_residue_number = protein_residue_number
 
     @property
     def pdb_path(self):
@@ -67,8 +72,24 @@ class PdbVariantSelection:
         return self._residue_number
 
     @property
+    def residue_id(self):
+        residue_id = str(self._residue_number)
+        if self._insertion_code is not None:
+            residue_id += self._insertion_code
+
+        return residue_id
+
+    @property
+    def protein_residue_number(self):
+        return self._protein_residue_number
+
+    @property
     def insertion_code(self):
         return self._insertion_code
+
+    @property
+    def protein_accession(self):
+        return self._protein_accession
 
     @property
     def wild_type_amino_acid(self):
@@ -96,11 +117,7 @@ class PdbVariantSelection:
         return hash(s)
 
     def __repr__(self):
-        residue_id = str(self._residue_number)
-        if self._insertion_code is not None:
-            residue_id += self._insertion_code
-
-        return "{}:{}:{}:{}->{}".format(self._pdb_path, self._chain_id, residue_id, self._wild_type_amino_acid, self._variant_amino_acid)
+        return "{}:{}:{}:{}->{}".format(self._pdb_path, self._chain_id, self.residue_id, self._wild_type_amino_acid, self._variant_amino_acid)
 
     @property
     def variant_class(self):

--- a/deeprank/operate/hdf5data.py
+++ b/deeprank/operate/hdf5data.py
@@ -41,6 +41,10 @@ def store_variant(variant_group, variant):
     variant_group.attrs['variant_amino_acid_name'] = variant.variant_amino_acid.name
     variant_group.attrs['wild_type_amino_acid_name'] = variant.wild_type_amino_acid.name
 
+    if variant.protein_accession is not None and variant.protein_residue_number is not None:
+        variant_group.attrs['variant_protein_accession'] = variant.protein_accession
+        variant_group.attrs['variant_protein_residue_number'] = variant.protein_residue_number
+
 
 def load_variant(variant_group):
     """ Loads the variant from the HDF5 variant group
@@ -68,12 +72,21 @@ def load_variant(variant_group):
     else:
         insertion_code = None
 
+    if 'variant_protein_accession' in variant_group.attrs and 'variant_protein_residue_number' in variant_group.attrs:
+
+        protein_accession = variant_group.attrs['variant_protein_accession']
+        protein_residue_number = variant_group.attrs['variant_protein_residue_number']
+    else:
+        protein_accession = None
+        protein_residue_number = None
+
     amino_acids_by_name = {amino_acid.name: amino_acid for amino_acid in amino_acids}
 
     variant_amino_acid = amino_acids_by_name[variant_group.attrs['variant_amino_acid_name']]
     wild_type_amino_acid = amino_acids_by_name[variant_group.attrs['wild_type_amino_acid_name']]
 
-    variant = PdbVariantSelection(pdb_path, chain_id, residue_number, wild_type_amino_acid, variant_amino_acid, pssm_paths_by_chain, insertion_code=insertion_code)
+    variant = PdbVariantSelection(pdb_path, chain_id, residue_number, wild_type_amino_acid, variant_amino_acid, pssm_paths_by_chain, insertion_code=insertion_code,
+                                  protein_accession=protein_accession, protein_residue_number=protein_residue_number)
 
     return variant
 

--- a/scripts/preprocess_bioprodict.py
+++ b/scripts/preprocess_bioprodict.py
@@ -176,9 +176,9 @@ def get_pdb_mappings(hdf5_path, pdb_root, pssm_root, variant_data):
         wt_amino_acid_code = swap[:3]
         residue_number = int(swap[3: -3])
         var_amino_acid_code = swap[-3:]
-        
+
         variants_section= variant_section.iloc[:20] 
- 
+
         for _, row in variants_section.iterrows():  # each row maps the variant to one pdb entry
 
             pdb_ac = row["pdb_structure"]
@@ -204,10 +204,13 @@ def get_pdb_mappings(hdf5_path, pdb_root, pssm_root, variant_data):
                 _log.warning("no pssms for {}".format(pdb_ac))
                 continue
 
+            protein_ac = row['protein_accession']
+
             variant = PdbVariantSelection(pdb_path, chain_id, pdb_number,
                                           amino_acids_by_code[wt_amino_acid_code],
                                           amino_acids_by_code[var_amino_acid_code],
-                                          pssm_paths, variant_class, insertion_code)
+                                          pssm_paths, variant_class, insertion_code,
+                                          protein_ac, residue_number)
 
             _log.debug("adding variant {}".format(variant))
 

--- a/test/test_learn.py
+++ b/test/test_learn.py
@@ -37,11 +37,13 @@ def test_learn():
        'atomic_densities': atomic_densities,
     }
 
-    variants = [PdbVariantSelection("test/101m.pdb", "A", 10, valine, cysteine, {"A": "test/101M.A.pdb.pssm"}),
+    variants = [PdbVariantSelection("test/101m.pdb", "A", 10, valine, cysteine, {"A": "test/101M.A.pdb.pssm"},
+                                    protein_accession="P02144", protein_residue_number=10),
                 PdbVariantSelection("test/data/pdb/5EYU/5EYU.pdb", "A", 8, serine, cysteine, {"A": "test/data/pssm/5EYU/5eyu.A.pdb.pssm",
                                                                                               "B": "test/data/pssm/5EYU/5eyu.B.pdb.pssm",
                                                                                               "C": "test/data/pssm/5EYU/5eyu.C.pdb.pssm",
-                                                                                              "D": "test/data/pssm/5EYU/5eyu.D.pdb.pssm"})]
+                                                                                              "D": "test/data/pssm/5EYU/5eyu.D.pdb.pssm"},
+                                    protein_accession="Q9L4P8")]
 
     work_dir_path = mkdtemp()
     try:


### PR DESCRIPTION
The deeprank learning algorithm generates a file named epoch_data.hdf5, containing predictions and target values, but little info on the variant. In this change, I increased the amount of information that is stored with the output. An additional hdf5 group called "variants" is added for every epoch. This will hold the variant information, like: structure, residue number amino acid change, protein accession.