### PR TITLE
Add a 3rd output class, labeled UNKNOWN.

### DIFF
--- a/deeprank/models/metrics.py
+++ b/deeprank/models/metrics.py
@@ -1,13 +1,16 @@
 import lzma
 import os
 import csv
-from typing import List, Tuple, Any
+from typing import List, Tuple, Any, Optional
 from math import sqrt
 
 from torch import argmax, tensor
 from torch.nn.functional import cross_entropy
 from torch.utils.tensorboard import SummaryWriter
 from sklearn.metrics import roc_auc_score
+
+from deeprank.models.variant import VariantClass
+from deeprank.tools.metrics import get_labels_from_output, get_labels_from_targets
 
 
 class MetricsExporter:
@@ -49,12 +52,19 @@ class MetricsExporterCollection:
             metrics_exporter.process(pass_name, epoch_number, entry_names, output_values, target_values)
 
 
-class TensorboardBinaryClassificationExporter(MetricsExporter):
-    "exports to tensorboard, works for binary classification only"
+class TensorboardVariantClassificationExporter(MetricsExporter):
+    "exports to tensorboard, works for variant classification only"
 
-    def __init__(self, directory_path):
+    def __init__(self, directory_path: str, unknown_treshold: Optional[float] = 0.5):
+        """
+        Args:
+            directory_path: where to store tensorboard files
+            unknown_treshold: if both class probabilities are below this value, give the class label UNKNOWN
+        """
+
         self._directory_path = directory_path
         self._writer = SummaryWriter(log_dir=directory_path)
+        self._unknown_treshold = unknown_treshold
 
     def __enter__(self):
         self._writer.__enter__()
@@ -67,33 +77,45 @@ class TensorboardBinaryClassificationExporter(MetricsExporter):
                 entry_names: List[str], output_values: List[Any], target_values: List[Any]):
         "write to tensorboard"
 
-        loss = cross_entropy(tensor(output_values), tensor(target_values))
+        output_tensor = tensor(output_values)
+        target_tensor = tensor(target_values)
+
+        loss = cross_entropy(output_tensor, target_tensor)
         self._writer.add_scalar(f"{pass_name} loss", loss, epoch_number)
 
-        probabilities = []
+        # lists of VariantClass values
+        prediction_labels = get_labels_from_output(output_tensor, unknown_treshold=self._unknown_treshold)
+        target_labels = get_labels_from_targets(target_tensor)
+
+        roc_probabilities = []  # floating point values
+        roc_targets = []  # list of 0/1 values
+
         fp, fn, tp, tn = 0, 0, 0, 0
         for entry_index, entry_name in enumerate(entry_names):
-            probability = output_values[entry_index][1]
-            probabilities.append(probability)
+            prediction_label = prediction_labels[entry_index]
+            target_label = target_labels[entry_index]
 
-            prediction_value = argmax(tensor(output_values[entry_index]))
-            target_value = target_values[entry_index]
-
-            if prediction_value > 0.0 and target_value > 0.0:
+            if prediction_label == VariantClass.PATHOGENIC and target_label == VariantClass.PATHOGENIC:
                 tp += 1
 
-            elif prediction_value <= 0.0 and target_value <= 0.0:
+            elif prediction_label == VariantClass.BENIGN and target_label == VariantClass.BENIGN:
                 tn += 1
 
-            elif prediction_value > 0.0 and target_value <= 0.0:
+            elif prediction_label == VariantClass.PATHOGENIC and target_label == VariantClass.BENIGN:
                 fp += 1
 
-            elif prediction_value <= 0.0 and target_value > 0.0:
+            elif prediction_label == VariantClass.BENIGN and target_label == VariantClass.PATHOGENIC:
                 fn += 1
+
+            if prediction_label != VariantClass.UNKNOWN:
+                roc_probabilities.append(output_values[entry_index][1])
+                roc_targets.append(target_values[entry_index])
+
+            # Furthermore, UNKNOWN variants are completely ignored..
 
         mcc_numerator = tn * tp - fp * fn
         if mcc_numerator == 0.0:
-             self._writer.add_scalar(f"{pass_name} MCC", 0.0, epoch_number)
+            self._writer.add_scalar(f"{pass_name} MCC", 0.0, epoch_number)
         else:
             mcc_denominator = sqrt((tn + fn) * (fp + tp) * (tn + fp) * (fn + tp))
 
@@ -101,12 +123,14 @@ class TensorboardBinaryClassificationExporter(MetricsExporter):
                 mcc = mcc_numerator / mcc_denominator
                 self._writer.add_scalar(f"{pass_name} MCC", mcc, epoch_number)
 
-        accuracy = (tp + tn) / (tp + tn + fp + fn)
-        self._writer.add_scalar(f"{pass_name} accuracy", accuracy, epoch_number)
+        accuracy_denominator = tp + tn + fp + fn
+        if accuracy_denominator > 0:
+            accuracy = (tp + tn) / accuracy_denominator
+            self._writer.add_scalar(f"{pass_name} accuracy", accuracy, epoch_number)
 
-        # for ROC curves to work, we need both class values in the set
-        if len(set(target_values)) == 2:
-            roc_auc = roc_auc_score(target_values, probabilities)
+        # for ROC curves to work, we need both class values in the target set
+        if len(set(roc_targets)) >= 2:
+            roc_auc = roc_auc_score(roc_targets, roc_probabilities)
             self._writer.add_scalar(f"{pass_name} ROC AUC", roc_auc, epoch_number)
 
 

--- a/deeprank/models/variant.py
+++ b/deeprank/models/variant.py
@@ -5,6 +5,7 @@ from deeprank.models.amino_acid import AminoAcid
 
 
 class VariantClass(Enum):
+    UNKNOWN = -1
     BENIGN = 0
     PATHOGENIC = 1
 

--- a/deeprank/tools/metrics.py
+++ b/deeprank/tools/metrics.py
@@ -5,24 +5,44 @@ import torch
 from deeprank.models.variant import VariantClass
 
 
-def get_labels_from_probabilities(probabilities: torch.tensor,
-                                  unknown_treshold: Optional[float] = 0.5) -> List[VariantClass]:
+def get_labels_from_output(output_data: torch.Tensor,
+                           unknown_treshold: Optional[float] = 0.5) -> List[VariantClass]:
     """
     Args:
-        probabilities: [x, 2] considered negative if left value > right value
+        output_data: [x, 2] considered BENIGN if left value > right value and otherwise PATHOGENIC
         unknown_treshold: if the values are both below this value, then consider the class UNKNOWN
     """
 
-    total = probabilities.shape[0]
+    total = output_data.shape[0]
 
     labels = []
     for index in range(total):
-        if probabilities[index, 0] < unknown_treshold and probabilities[index, 1] < unknown_treshold:
+        if output_data[index, 0] < unknown_treshold and output_data[index, 1] < unknown_treshold:
             label = VariantClass.UNKNOWN
 
-        elif probabilities[index, 0] < probabilities[index, 1]:
+        elif output_data[index, 0] < output_data[index, 1]:
             label = VariantClass.PATHOGENIC
 
+        else:
+            label = VariantClass.BENIGN
+
+        labels.append(label)
+
+    return labels
+
+
+def get_labels_from_targets(target_data: torch.Tensor) -> List[VariantClass]:
+    """
+    Args:
+        target_data: [x, 1] where 0 means BENIGN and 1 means PATHOGENIC
+    """
+
+    total = target_data.shape[0]
+
+    labels = []
+    for index in range(total):
+        if target_data[index] > 0:
+            label = VariantClass.PATHOGENIC
         else:
             label = VariantClass.BENIGN
 

--- a/deeprank/tools/metrics.py
+++ b/deeprank/tools/metrics.py
@@ -1,74 +1,31 @@
-from math import sqrt
+from typing import List, Optional
+
+import torch
+
+from deeprank.models.variant import VariantClass
 
 
-def get_tp_tn_fp_fn(output_data, target_data):
-    """ A classification metric
-
+def get_labels_from_probabilities(probabilities: torch.tensor,
+                                  unknown_treshold: Optional[float] = 0.5) -> List[VariantClass]:
+    """
     Args:
-        output_data(array of dimension (x,2)): considered negative if left value > right value
-        target_data(array of dimension (x,1)): considered negative if 0, positive otherewise
-
-    Returns (four floats):
-        true positive count (tp)
-        true negative count (tn)
-        false positive count (fp)
-        false negative count (fn)
+        probabilities: [x, 2] considered negative if left value > right value
+        unknown_treshold: if the values are both below this value, then consider the class UNKNOWN
     """
 
-    tp = 0
-    tn = 0
-    fp = 0
-    fn = 0
+    total = probabilities.shape[0]
 
-    total = output_data.shape[0]
-    if total == 0:
-        raise ValueError("0 output data entries")
-
+    labels = []
     for index in range(total):
-        output0, output1 = output_data[index,:]
-        target = target_data[index]
+        if probabilities[index, 0] < unknown_treshold and probabilities[index, 1] < unknown_treshold:
+            label = VariantClass.UNKNOWN
 
-        if output0 > output1:  # negative output
+        elif probabilities[index, 0] < probabilities[index, 1]:
+            label = VariantClass.PATHOGENIC
 
-            if target != 0:  # wrong
+        else:
+            label = VariantClass.BENIGN
 
-                fn += 1
+        labels.append(label)
 
-            else:  # right
-
-                tn += 1
-
-        else:  # positive output
-
-            if target != 0:  # right
-
-                tp += 1
-
-            else:  # wrong
-
-                fp += 1
-
-    return tp, tn, fp, fn
-
-
-def get_mcc(tp, tn, fp, fn):
-    """ The Mathews Correlation Coefficient
-
-    Args:
-        tp (float): true positive count
-        tn (float): true negative count
-        fp (float): false positive count
-        fn (float): false negative count
-
-    Returns (float): Mathews Correlation Coefficient
-    """
-
-    numerator = tp * tn - fp * fn
-    if numerator == 0:
-        return 0.0
-
-    denominator = sqrt((tp + fp) * (tp + fn) * (tn + fp) * (tn + fn))
-    if denominator == 0:
-        raise ValueError(f"MCC denominator is zero for tp={tp}, tn={tn}, fp={fp}, fn={fn}")
-
-    return numerator / denominator
+    return labels

--- a/scripts/learn.py
+++ b/scripts/learn.py
@@ -14,7 +14,7 @@ from deeprank.learn.NeuralNet import NeuralNet
 from deeprank.learn.DataSet import DataSet
 from deeprank.learn.model3d import cnn_class
 from deeprank.models.metrics import OutputExporter
-from deeprank.models.metrics import TensorboardBinaryClassificationExporter
+from deeprank.models.metrics import TensorboardVariantClassificationExporter
 
 
 logging.basicConfig(filename="learn-%d.log" % os.getpid(), filemode="w", level=logging.INFO)
@@ -80,6 +80,6 @@ if __name__ == "__main__":
 
     neural_net = NeuralNet(dataset, cnn_class, model_type='3d',task='class', cuda=False,
                            metrics_exporters=[OutputExporter(run_directory),
-                                              TensorboardBinaryClassificationExporter(run_directory)])
+                                              TensorboardVariantClassificationExporter(run_directory)])
     neural_net.optimizer = optim.AdamW(neural_net.net.parameters(), lr=0.001, weight_decay=0.005)
     neural_net.train(nepoch = epoch_count, divide_trainset=None, train_batch_size = 5, num_workers=0)

--- a/test/models/test_metrics.py
+++ b/test/models/test_metrics.py
@@ -2,7 +2,7 @@ import tempfile
 import shutil
 import os
 
-from deeprank.models.metrics import TensorboardBinaryClassificationExporter, OutputExporter
+from deeprank.models.metrics import TensorboardVariantClassificationExporter, OutputExporter
 
 
 test_entries = ["entry0", "entry1"]
@@ -14,7 +14,7 @@ def test_tensorboard_class_output():
 
     tmp_dir_path = tempfile.mkdtemp()
     try:
-        exporter = TensorboardBinaryClassificationExporter(tmp_dir_path)
+        exporter = TensorboardVariantClassificationExporter(tmp_dir_path)
 
         with exporter:
             exporter.process("unit-testing", 0, test_entries, test_outputs, test_targets)

--- a/test/test_learn.py
+++ b/test/test_learn.py
@@ -14,7 +14,7 @@ from deeprank.learn.NeuralNet import NeuralNet
 from deeprank.learn.model3d import cnn_class
 from deeprank.models.environment import Environment
 from deeprank.domain.amino_acid import *
-from deeprank.models.metrics import OutputExporter, TensorboardBinaryClassificationExporter
+from deeprank.models.metrics import OutputExporter, TensorboardVariantClassificationExporter
 import deeprank.config
 
 
@@ -81,7 +81,7 @@ def test_learn():
 
         neural_net = NeuralNet(dataset, cnn_class, model_type='3d',task='class',
                                cuda=False, metrics_exporters=[OutputExporter(metrics_directory),
-                                                              TensorboardBinaryClassificationExporter(metrics_directory)])
+                                                              TensorboardVariantClassificationExporter(metrics_directory)])
 
         neural_net.optimizer = optim.SGD(neural_net.net.parameters(),
                                          lr=0.001,

--- a/test/tools/test_metrics.py
+++ b/test/tools/test_metrics.py
@@ -1,16 +1,28 @@
 import torch
 
 from deeprank.models.variant import VariantClass
-from deeprank.tools.metrics import get_labels_from_probabilities
+from deeprank.tools.metrics import get_labels_from_output, get_labels_from_targets
 
 
-def test_labels_from_probabililties():
+def test_labels_from_output():
     data = torch.tensor([[0.1, -0.1],
                          [0.0, 1.1],
                          [1.2, -0.1]])
 
-    labels = get_labels_from_probabilities(data)
+    labels = get_labels_from_output(data)
 
     assert labels == [VariantClass.UNKNOWN,
                       VariantClass.PATHOGENIC,
+                      VariantClass.BENIGN], f"labels are {labels}"
+
+
+def get_labels_from_targets():
+    data = torch.tensor([[0], [1], [1], [0], [0]])
+
+    labels = get_labels_from_targets(data)
+
+    assert labels == [VariantClass.BENIGN,
+                      VariantClass.PATHOGENIC,
+                      VariantClass.PATHOGENIC,
+                      VariantClass.BENIGN,
                       VariantClass.BENIGN], f"labels are {labels}"

--- a/test/tools/test_metrics.py
+++ b/test/tools/test_metrics.py
@@ -1,0 +1,16 @@
+import torch
+
+from deeprank.models.variant import VariantClass
+from deeprank.tools.metrics import get_labels_from_probabilities
+
+
+def test_labels_from_probabililties():
+    data = torch.tensor([[0.1, -0.1],
+                         [0.0, 1.1],
+                         [1.2, -0.1]])
+
+    labels = get_labels_from_probabilities(data)
+
+    assert labels == [VariantClass.UNKNOWN,
+                      VariantClass.PATHOGENIC,
+                      VariantClass.BENIGN], f"labels are {labels}"


### PR DESCRIPTION
When calculating MCC, accuracy and ROC AUC values in tensorboard, consider the following 3 class labels:
- BENIGN: when the CNN outputs a higher number on the left side, than on the right side
- PATHOGENIC: when the CNN outputs a higher number on the right side, than on the left side
- UNKNOWN: when the CNN outputs two numbers below 0.5

BENIGN and PATHOGENIC both contribute to the MCC, accuracy and ROC values. Outputs of UNKNOWN however, are left out of the equation. They don't contribute to these scores. Furthermore, loss values are still calculated in the same way as before. So this change will not affect CNN training. Only the scores are calculated in a different way. @rgayatri is this what you intended?